### PR TITLE
Replace hardcoded URLs with external app config constant

### DIFF
--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -1,5 +1,6 @@
 import { Link, NavLink } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { EXTERNAL_APP_BASE_URL } from "@/config";
 import { isAdmin } from "@/services/auth";
 
 export function NavBar() {
@@ -62,18 +63,18 @@ export function NavBar() {
             <Link to="/courses">Start Learning</Link>
           </Button>
           <Button asChild>
-            <Link to="/badges">Badges</Link>
-          </Button>
+        <a href={`${EXTERNAL_APP_BASE_URL}/badges`}>Badges</a>
+      </Button>
           {isAdmin() && (
             <Button asChild variant="outline">
               <Link to="/admin">Admin</Link>
             </Button>
           )}
           <Button asChild variant="outline">
-            <Link to="/auth" target="_blank" rel="noreferrer">
-              Sign In
-            </Link>
-          </Button>
+        <a href={`${EXTERNAL_APP_BASE_URL}/auth`} rel="noreferrer">
+          Sign In
+        </a>
+      </Button>
         </div>
       </div>
     </header>

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -63,18 +63,18 @@ export function NavBar() {
             <Link to="/courses">Start Learning</Link>
           </Button>
           <Button asChild>
-        <a href={`${EXTERNAL_APP_BASE_URL}/badges`}>Badges</a>
-      </Button>
+            <a href={`${EXTERNAL_APP_BASE_URL}/badges`}>Badges</a>
+          </Button>
           {isAdmin() && (
             <Button asChild variant="outline">
               <Link to="/admin">Admin</Link>
             </Button>
           )}
           <Button asChild variant="outline">
-        <a href={`${EXTERNAL_APP_BASE_URL}/auth`} rel="noreferrer">
-          Sign In
-        </a>
-      </Button>
+            <a href={`${EXTERNAL_APP_BASE_URL}/auth`} rel="noreferrer">
+              Sign In
+            </a>
+          </Button>
         </div>
       </div>
     </header>

--- a/client/config.ts
+++ b/client/config.ts
@@ -1,1 +1,2 @@
-export const EXTERNAL_APP_BASE_URL = "https://48143afbaa824147b5601917a174d2ec-426306e386634daaba4c5fd08.fly.dev";
+export const EXTERNAL_APP_BASE_URL =
+  "https://48143afbaa824147b5601917a174d2ec-426306e386634daaba4c5fd08.fly.dev";

--- a/client/config.ts
+++ b/client/config.ts
@@ -1,0 +1,1 @@
+export const EXTERNAL_APP_BASE_URL = "https://48143afbaa824147b5601917a174d2ec-426306e386634daaba4c5fd08.fly.dev";

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -5,6 +5,7 @@ import { CourseCard } from "@/components/CourseCard";
 import { LeaderboardPreview } from "@/components/LeaderboardPreview";
 import { RewardsPreview } from "@/components/RewardsPreview";
 import { Button } from "@/components/ui/button";
+import { EXTERNAL_APP_BASE_URL } from "@/config";
 
 export default function Index() {
   const [level, setLevel] = useState<EducationLevel>(
@@ -35,8 +36,7 @@ export default function Index() {
                   className="h-6 w-6 rounded-md object-cover"
                 />
                 <a
-                  href="https://d695dee0c3c54d5cb882ace3593e0e19-f6d62edd306142089ce873f0f.fly.dev/simulation"
-                  target="_blank"
+                  href={`${EXTERNAL_APP_BASE_URL}/simulation`}
                   rel="noreferrer"
                   className="flex cursor-pointer pointer-events-auto font-semibold"
                 >
@@ -73,8 +73,7 @@ export default function Index() {
               <div className="mt-8 flex flex-wrap gap-3">
                 <Button asChild size="lg">
                   <a
-                    href="https://d695dee0c3c54d5cb882ace3593e0e19-f6d62edd306142089ce873f0f.fly.dev/simulation"
-                    target="_blank"
+                    href={`${EXTERNAL_APP_BASE_URL}/simulation`}
                     rel="noreferrer"
                     className="pointer-events-auto cursor-pointer"
                   >
@@ -83,7 +82,7 @@ export default function Index() {
                 </Button>
                 <Button asChild variant="outline" size="lg">
                   <a
-                    href="https://d695dee0c3c54d5cb882ace3593e0e19-f6d62edd306142089ce873f0f.fly.dev/courses"
+                    href={`${EXTERNAL_APP_BASE_URL}/courses`}
                     className="pointer-events-auto cursor-pointer"
                   >
                     Explore Courses
@@ -152,7 +151,7 @@ export default function Index() {
                   className="bg-white text-emerald-900 hover:bg-emerald-100"
                 >
                   <a
-                    href="https://d695dee0c3c54d5cb882ace3593e0e19-f6d62edd306142089ce873f0f.fly.dev/simulation"
+                    href={`${EXTERNAL_APP_BASE_URL}/simulation`}
                     rel="noreferrer"
                     className="pointer-events-auto cursor-pointer"
                   >


### PR DESCRIPTION
## Purpose
Based on the conversation context, the user wanted to refactor hardcoded external URLs to use a centralized configuration approach for better maintainability and consistency across the application.

## Code changes
- **Created new config file**: Added `client/config.ts` with `EXTERNAL_APP_BASE_URL` constant pointing to the external Fly.dev application
- **Updated NavBar component**: Replaced hardcoded links for "Badges" and "Sign In" buttons with external URLs using the new config constant
- **Updated Index page**: Replaced multiple hardcoded Fly.dev URLs in simulation and course links with the centralized config constant
- **Removed target="_blank"**: Cleaned up unnecessary `target="_blank"` attributes from some external links while maintaining `rel="noreferrer"` for security

The changes centralize external URL management and make the codebase more maintainable by eliminating duplicate hardcoded URLs throughout the application.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/48143afbaa824147b5601917a174d2ec/stellar-works)

👀 [Preview Link](https://48143afbaa824147b5601917a174d2ec-stellar-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>48143afbaa824147b5601917a174d2ec</projectId>-->
<!--<branchName>stellar-works</branchName>-->